### PR TITLE
changing from source_format to target_format to match preceding setting of '2H' value

### DIFF
--- a/pyscada/models.py
+++ b/pyscada/models.py
@@ -827,7 +827,7 @@ class Variable(models.Model):
             byte_order = self.device.byte_order
         else:
             byte_order = self.byte_order
-        if source_format == '2H':
+        if target_format == '2H':
             if byte_order == '1-0-3-2':
                 return output
             if byte_order == '3-2-1-0':


### PR DESCRIPTION
Hi Guys,

This line seemed be referencing the wrong variable based mostly on the expected value.  I haven't done a lot of testing but this change did clear exceptions in my logs.  Reading and Writing 'Real' values is now working fine.

Shannon